### PR TITLE
Update for HA 0.115 Chances

### DIFF
--- a/weather-card-chart.js
+++ b/weather-card-chart.js
@@ -172,7 +172,7 @@ class WeatherCardChart extends Polymer.Element {
               <ha-icon icon="hass:weather-windy"></ha-icon> [[computeWind(weatherObj.attributes.wind_speed)]] [[ll('uSpeed')]]
             </div>
           </div>
-          <ha-chart-base data="[[ChartData]]"></ha-chart-base>
+          <ha-chart-base hass="[[_hass]]" data="[[ChartData]]"></ha-chart-base>
           <div class="conditions">
             <template is="dom-repeat" items="[[forecast]]">
               <div>


### PR DESCRIPTION
This PR adds the `hass` parameter to `ha-chart-base` which is now required as of HA version 0.115 per [HA Frontend PR 6671](https://github.com/home-assistant/frontend/pull/6671).