### PR TITLE
make top left icon align (correctly) left

### DIFF
--- a/weather-card-chart.js
+++ b/weather-card-chart.js
@@ -136,7 +136,7 @@ class WeatherCardChart extends Polymer.Element {
           margin: 10px 0px 10px 0px;
         }
         .attributes div {
-          text-align: center;
+          text-align: left;
         }
         .conditions {
           display: flex;


### PR DESCRIPTION
humidity is the only icon not showing on its correct spot in the grid. this fixes that

from:

<img width="334" alt="Schermafbeelding 2020-09-23 om 09 10 47" src="https://user-images.githubusercontent.com/33354141/93978991-0d0e4600-fd7d-11ea-9185-8831f261ddf8.png">

to

<img width="337" alt="Schermafbeelding 2020-09-23 om 09 09 39" src="https://user-images.githubusercontent.com/33354141/93979029-18fa0800-fd7d-11ea-9264-7f8e850a0a39.png">
