### PR TITLE
Improve check of weatherObj attributes

### DIFF
--- a/weather-card-chart.js
+++ b/weather-card-chart.js
@@ -304,6 +304,9 @@ class WeatherCardChart extends Polymer.Element {
   }
 
   drawChart() {
+    if (!this.weatherObj.attributes || !this.weatherObj.attributes.forecast) {
+      return [];
+    }
     var data = this.weatherObj.attributes.forecast.slice(0,9);
     var locale = this._hass.selectedLanguage || this._hass.language;
     var tempUnit = this._hass.config.unit_system.temperature;
@@ -311,9 +314,6 @@ class WeatherCardChart extends Polymer.Element {
     var precipUnit = lengthUnit === 'km' ? this.ll('uPrecip') : 'in';
     var mode = this.mode;
     var i;
-    if (!this.weatherObj.attributes.forecast) {
-      return [];
-    }
     var dateTime = [];
     var tempHigh = [];
     var tempLow = [];


### PR DESCRIPTION
Error: 
**_weather-card-chart.js:307:43 Uncaught TypeError: Cannot read property 'forecast' of undefined_**

The check of `weatherObj` have moved earlier in the `drawChart` function and extended to also check that `weatherObj.attributes` exist 